### PR TITLE
feat: add vitest to generated extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-tiptap-extension",
-  "version": "1.0.0",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-tiptap-extension",
-      "version": "1.0.0",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.2.0",

--- a/templates/extension-js/package.json
+++ b/templates/extension-js/package.json
@@ -7,20 +7,27 @@
   ],
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
+  "type": "module",
   "scripts": {
     "clean": "rm -rf dist",
     "build": "npm run clean && rollup -c",
-    "dev": "npm run clean && rollup -c -w"
+    "dev": "npm run clean && rollup -c -w",
+    "test": "vitest"
   },
   "devDependencies": {
     "@babel/core": "^7.21.0",
     "@rollup/plugin-babel": "^6.0.3",
     "@rollup/plugin-commonjs": "^24.0.1",
     "@tiptap/core": "^2.0.0-beta.220",
+    "@tiptap/extension-document": "^2.10.2",
+    "@tiptap/extension-paragraph": "^2.10.2",
+    "@tiptap/extension-text": "^2.10.2",
     "@tiptap/pm": "^2.0.0-beta.220",
+    "jsdom": "^25.0.1",
     "rollup": "^3.17.3",
     "rollup-plugin-auto-external": "^2.0.0",
-    "rollup-plugin-sourcemaps": "^0.6.3"
+    "rollup-plugin-sourcemaps": "^0.6.3",
+    "vitest": "^2.1.5"
   },
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.220",

--- a/templates/extension-js/src/index.js
+++ b/templates/extension-js/src/index.js
@@ -1,11 +1,22 @@
-import { Extension } from '@tiptap/core'
+import { Extension } from "@tiptap/core";
 
 const MyExtension = Extension.create({
   name: "MyExtension",
 
-  // do your stuff here
-})
+  // Add more extension configurations here...
 
-export { MyExtension }
+  addCommands() {
+    return {
+      myCommand:
+        () =>
+        ({ commands }) => {
+          return commands.insertContent("<p>My Extension</p>");
+        },
+      // Add more commands here...
+    };
+  },
+});
 
-export default MyExtension
+export { MyExtension };
+
+export default MyExtension;

--- a/templates/extension-js/src/index.test.js
+++ b/templates/extension-js/src/index.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { Editor } from "@tiptap/core";
+import { JSDOM } from "jsdom";
+import Document from "@tiptap/extension-document";
+import Paragraph from "@tiptap/extension-paragraph";
+import Text from "@tiptap/extension-text";
+import path from "path";
+
+import MyExtension from "./index";
+
+let dom, document;
+
+describe("MyExtension", () => {
+  beforeAll(async () => {
+    dom = await JSDOM.fromFile(path.resolve(__dirname, "test.dom.html"), {
+      contentType: "text/html",
+    });
+    document = dom.window.document;
+  });
+
+  describe("Initialization", () => {
+    it("initializes without errors", () => {
+      const editor = new Editor({
+        element: document.querySelector("#editor"),
+        content: "<p>Example Text</p>",
+        extensions: [Document, Paragraph, Text, MyExtension],
+      });
+      expect(editor).toBeTruthy();
+    });
+
+    it("allows extension access via editor", () => {
+      const editor = new Editor({
+        element: document.querySelector("#editor"),
+        content: "<p>Example Text</p>",
+        extensions: [Document, Paragraph, Text, MyExtension],
+      });
+
+      const myExtension = editor.extensionManager.extensions.find(
+        (extension) => extension.name === "MyExtension"
+      );
+
+      expect(myExtension).toBeTruthy();
+    });
+  });
+
+  describe("Commands", () => {
+    it("defines commands within the editor", () => {
+      const editor = new Editor({
+        element: document.querySelector("#editor"),
+        content: "<p>Example Text</p>",
+        extensions: [Document, Paragraph, Text, MyExtension],
+      });
+
+      expect(editor.commands.myCommand).toBeDefined();
+    });
+
+    it("allows command extensions to be called via editor commands", () => {
+      const editor = new Editor({
+        element: document.querySelector("#editor"),
+        content: "<p>Example Text</p>",
+        extensions: [Document, Paragraph, Text, MyExtension],
+      });
+
+      editor.commands.myCommand();
+
+      expect(editor.getText()).toContain("My Extension");
+    });
+  });
+});

--- a/templates/extension-js/src/test.dom.html
+++ b/templates/extension-js/src/test.dom.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tiptap Extension - Test Document</title>
+  </head>
+  <body>
+    <div id="editor"></div>
+  </body>
+</html>

--- a/templates/extension-js/vitest.config.js
+++ b/templates/extension-js/vitest.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+  },
+});

--- a/templates/extension-ts/package.json
+++ b/templates/extension-ts/package.json
@@ -5,22 +5,29 @@
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
+  "type": "module",
   "scripts": {
     "clean": "rm -rf dist",
     "build": "npm run clean && rollup -c",
-    "dev": "npm run clean && rollup -c -w"
+    "dev": "npm run clean && rollup -c -w",
+    "test": "vitest"
   },
   "devDependencies": {
     "@babel/core": "^7.21.0",
     "@rollup/plugin-babel": "^6.0.3",
     "@rollup/plugin-commonjs": "^24.0.1",
     "@tiptap/core": "^2.0.0-beta.220",
+    "@tiptap/extension-document": "^2.10.2",
+    "@tiptap/extension-paragraph": "^2.10.2",
+    "@tiptap/extension-text": "^2.10.2",
     "@tiptap/pm": "^2.0.0-beta.220",
+    "jsdom": "^25.0.1",
     "rollup": "^3.17.3",
     "rollup-plugin-auto-external": "^2.0.0",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "rollup-plugin-typescript2": "^0.34.1",
-    "typescript": "^4.9.5"
+    "typescript": "^4.9.5",
+    "vitest": "^2.1.5"
   },
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.220",

--- a/templates/extension-ts/src/index.test.ts
+++ b/templates/extension-ts/src/index.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import { Editor } from "@tiptap/core";
+import { JSDOM } from "jsdom";
+import Document from "@tiptap/extension-document";
+import Paragraph from "@tiptap/extension-paragraph";
+import Text from "@tiptap/extension-text";
+import path from "path";
+
+import MyExtension from "./index";
+
+let dom, document;
+
+describe("MyExtension", () => {
+  beforeAll(async () => {
+    dom = await JSDOM.fromFile(path.resolve(__dirname, "test.dom.html"), {
+      contentType: "text/html",
+    });
+    document = dom.window.document;
+  });
+
+  describe("Initialization", () => {
+    it("initializes without errors", () => {
+      const editor = new Editor({
+        element: document.querySelector("#editor"),
+        content: "<p>Example Text</p>",
+        extensions: [Document, Paragraph, Text, MyExtension],
+      });
+      expect(editor).toBeTruthy();
+    });
+
+    it("allows extension access via editor", () => {
+      const editor = new Editor({
+        element: document.querySelector("#editor"),
+        content: "<p>Example Text</p>",
+        extensions: [Document, Paragraph, Text, MyExtension],
+      });
+
+      const myExtension = editor.extensionManager.extensions.find(
+        (extension) => extension.name === "MyExtension"
+      );
+
+      expect(myExtension).toBeTruthy();
+    });
+  });
+
+  describe("Commands", () => {
+    it("defines commands within the editor", () => {
+      const editor = new Editor({
+        element: document.querySelector("#editor"),
+        content: "<p>Example Text</p>",
+        extensions: [Document, Paragraph, Text, MyExtension],
+      });
+
+      expect(editor.commands.myCommand).toBeDefined();
+    });
+
+    it("allows command extensions to be called via editor commands", () => {
+      const editor = new Editor({
+        element: document.querySelector("#editor"),
+        content: "<p>Example Text</p>",
+        extensions: [Document, Paragraph, Text, MyExtension],
+      });
+
+      editor.commands.myCommand();
+
+      expect(editor.getText()).toContain("My Extension");
+    });
+  });
+});

--- a/templates/extension-ts/src/index.ts
+++ b/templates/extension-ts/src/index.ts
@@ -1,11 +1,22 @@
-import { Extension } from '@tiptap/core'
+import { Extension } from "@tiptap/core";
 
 const MyExtension = Extension.create({
-  name: 'MyExtension',
+  name: "MyExtension",
 
-  // do your stuff here
-})
+  // Add more extension configurations here...
 
-export { MyExtension }
+  addCommands() {
+    return {
+      myCommand:
+        () =>
+        ({ commands }) => {
+          return commands.insertContent("<p>My Extension</p>");
+        },
+      // Add more commands here...
+    };
+  },
+});
 
-export default MyExtension
+export { MyExtension };
+
+export default MyExtension;

--- a/templates/extension-ts/src/test.dom.html
+++ b/templates/extension-ts/src/test.dom.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tiptap Extension - Test Document</title>
+  </head>
+  <body>
+    <div id="editor"></div>
+  </body>
+</html>

--- a/templates/extension-ts/vitest.config.js
+++ b/templates/extension-ts/vitest.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+  },
+});


### PR DESCRIPTION
This PR aims to add support for [Vitest](https://vitest.dev/) so the end user can test their extension easily with an already configured vitest environment and some simple tests already setup.

This PR includes the basic core dependencies needed in order to properly mount the `Tiptap` editor within the DOM. These dependencies include:

- `jsdom`: enables to have a simulated DOM within the test environment.
- `@tiptap/extension-document`: basic `Tiptap` extension to allow the document generation.
- `@tiptap/extension-paragraph`: basic `Tiptap` exntesion to allow working with paragraphs.
- `@tiptap/extension-text`: basic `Tiptap` extension to allow working with plain text.
- `vitest`: the testing library used to run tests. Much performant than `Jest`.

Example output from the test runner after the extension has been created:

```
$ vitest


 DEV  v2.1.5 /Users/alexvcasillas/tiptap/create-tiptap-extension/tiptap-extension

 ✓ src/index.test.js (4)
   ✓ MyExtension (4)
     ✓ Initialization (2)
       ✓ initializes without errors
       ✓ allows extension access via editor
     ✓ Commands (2)
       ✓ defines commands within the editor
       ✓ allows command extensions to be called via editor commands

 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  13:35:15
   Duration  344ms (transform 14ms, setup 0ms, collect 26ms, tests 35ms, environment 164ms, prepare 28ms)
```

We could extend these predefined tests as much as we would like to, but for someone to get started with extension creation, having the extension and a predefined editor command seems a good point on getting started with `Tiptap`.